### PR TITLE
fix(ci): refresh cargo-vet exemptions for tempfile 3.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -462,15 +462,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "memchr"
@@ -737,15 +737,15 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -852,15 +852,15 @@ checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1035,7 +1035,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -217,11 +217,11 @@ version = "0.3.85"
 criteria = "safe-to-run"
 
 [[exemptions.libc]]
-version = "0.2.180"
+version = "0.2.182"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
-version = "0.11.0"
+version = "0.12.1"
 criteria = "safe-to-run"
 
 [[exemptions.memchr]]
@@ -341,7 +341,7 @@ version = "0.8.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustix]]
-version = "1.1.3"
+version = "1.1.4"
 criteria = "safe-to-run"
 
 [[exemptions.rustversion]]
@@ -393,7 +393,7 @@ version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
-version = "3.25.0"
+version = "3.26.0"
 criteria = "safe-to-run"
 
 [[exemptions.termtree]]


### PR DESCRIPTION
## Summary
- supersede #39 with an independent PR off `master`
- bump `tempfile` to `3.26.0` in `Cargo.lock` (including transitive lockfile updates)
- refresh `cargo-vet` exemptions for `libc 0.2.182`, `linux-raw-sys 0.12.1`, `rustix 1.1.4`, and `tempfile 3.26.0`

## Why
- PR #39 fails in CI at `mise run vet` because the new dependency versions are unvetted
- this change carries the dependency bump plus the required vet metadata so CI passes

## Validation
- `mise run vet`
- `mise run check` *(all stages pass except `msrv` in this environment due existing read-only filesystem/logging limitation)*
- `gh pr checks 40 --repo bedecarroll/cfgcut --watch --fail-fast`
