### PR TITLE
fix(ci): merge dependabot updates and restore pycfgcut builds

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -137,7 +137,7 @@ jobs:
           "$VENV_PYTHON" -m pytest crates/pycfgcut/tests
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: dist
@@ -155,7 +155,7 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -180,14 +180,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -205,7 +205,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -230,14 +230,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -250,14 +250,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/crates/pycfgcut/pyproject.toml
+++ b/crates/pycfgcut/pyproject.toml
@@ -39,5 +39,4 @@ Changelog = "https://github.com/bedecarroll/cfgcut/blob/main/CHANGELOG.md"
 [tool.maturin]
 bindings = "pyo3-abi3"
 module-name = "pycfgcut"
-strip = true
 sdist-include = ["src", "Cargo.toml", "README.md", "LICENSE", "../cfgcut/**"]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,4 +19,4 @@ precise-builds = true
 install-path = "~/.local/bin"
 # Whether to install an updater program
 install-updater = false
-github-action-commits = { "actions/checkout" = "v6", "actions/upload-artifact" = "v6", "actions/download-artifact" = "v7" }
+github-action-commits = { "actions/checkout" = "v6", "actions/upload-artifact" = "v7", "actions/download-artifact" = "v8" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -405,7 +405,7 @@ version = "1.2.1"
 criteria = "safe-to-run"
 
 [[exemptions.toml]]
-version = "1.0.3+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.toml_datetime]]


### PR DESCRIPTION
Summary
- supersede #41 and #42 with one trunk-based fix
- update the `toml` lockfile to `1.0.4+spec-1.1.0` and refresh the matching cargo-vet exemption
- move the dist-managed workflow pins to `actions/upload-artifact@v7` and `actions/download-artifact@v8`, regenerate `.github/workflows/release.yml`, and mirror the same bump in `.github/workflows/python-release.yml`
- remove `strip = true` from `pycfgcut` so current `maturin` releases stop failing on `--include-debuginfo` plus `--strip`

Why
- #41 edits a generated release workflow directly, but `cargo-dist` owns `.github/workflows/release.yml`, so the durable fix has to live in `dist-workspace.toml`
- #42 brings in the intended `toml` bump, but the repo still needs the corresponding `cargo-vet` update once the Python packaging failure is fixed
- both open PRs fail the Python build because current `maturin` rejects the existing strip setting during release builds

Validation
- `mise run pytest`
- `mise run check` (local env only: reaches `mise run msrv`, then `cargo-msrv` panics with `Os { code: 30, kind: ReadOnlyFilesystem }` while creating its log file)
- `mise run dist-plan`
- `python -m maturin build --manifest-path crates/pycfgcut/Cargo.toml --release --locked --out dist`
- install built wheel and run `pytest crates/pycfgcut/tests`
