### PR TITLE
fix(ci): unblock clap and toml dependency refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,9 +49,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -835,9 +835,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.4+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -896,27 +896,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "unicode-ident"
@@ -1134,9 +1134,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://cfgcut.bedecarroll.com"
 
 [workspace.dependencies]
 assert_cmd = "2"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 glob = "0.3"
 insta = { version = "1", features = ["yaml"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -20,12 +20,20 @@ criteria = "safe-to-run"
 version = "0.6.21"
 criteria = "safe-to-deploy"
 
+[[exemptions.anstream]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.anstyle]]
 version = "1.0.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.anstyle-parse]]
 version = "0.2.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-parse]]
+version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.anstyle-query]]
@@ -92,6 +100,10 @@ criteria = "safe-to-deploy"
 version = "4.5.60"
 criteria = "safe-to-deploy"
 
+[[exemptions.clap]]
+version = "4.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.clap_builder]]
 version = "4.5.59"
 criteria = "safe-to-deploy"
@@ -100,8 +112,16 @@ criteria = "safe-to-deploy"
 version = "4.5.60"
 criteria = "safe-to-deploy"
 
+[[exemptions.clap_builder]]
+version = "4.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.clap_derive]]
 version = "4.5.55"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_derive]]
+version = "4.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
@@ -320,6 +340,10 @@ criteria = "safe-to-deploy"
 version = "1.0.44"
 criteria = "safe-to-deploy"
 
+[[exemptions.quote]]
+version = "1.0.45"
+criteria = "safe-to-deploy"
+
 [[exemptions.r-efi]]
 version = "5.3.0"
 criteria = "safe-to-run"
@@ -376,6 +400,10 @@ criteria = "safe-to-deploy"
 version = "1.0.4"
 criteria = "safe-to-run"
 
+[[exemptions.serde_spanned]]
+version = "1.1.0"
+criteria = "safe-to-run"
+
 [[exemptions.shlex]]
 version = "1.3.0"
 criteria = "safe-to-deploy"
@@ -390,6 +418,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
 version = "2.0.114"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "2.0.117"
 criteria = "safe-to-deploy"
 
 [[exemptions.target-lexicon]]
@@ -420,16 +452,48 @@ criteria = "safe-to-run"
 version = "1.0.6+spec-1.1.0"
 criteria = "safe-to-run"
 
+[[exemptions.toml]]
+version = "1.0.7+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml]]
+version = "1.1.0+spec-1.1.0"
+criteria = "safe-to-run"
+
 [[exemptions.toml_datetime]]
 version = "1.0.0+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_datetime]]
+version = "1.0.1+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_datetime]]
+version = "1.1.0+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.toml_parser]]
 version = "1.0.9+spec-1.1.0"
 criteria = "safe-to-run"
 
+[[exemptions.toml_parser]]
+version = "1.0.10+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_parser]]
+version = "1.1.0+spec-1.1.0"
+criteria = "safe-to-run"
+
 [[exemptions.toml_writer]]
 version = "1.0.6+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_writer]]
+version = "1.0.7+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_writer]]
+version = "1.1.0+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.unicode-ident]]
@@ -542,6 +606,10 @@ criteria = "safe-to-run"
 
 [[exemptions.winnow]]
 version = "0.7.14"
+criteria = "safe-to-run"
+
+[[exemptions.winnow]]
+version = "1.0.0"
 criteria = "safe-to-run"
 
 [[exemptions.wit-bindgen]]


### PR DESCRIPTION
Supersedes failed Dependabot PR #47.

Local validation:
- `mise run vet` passed after adding the required cargo-vet exemptions for the refreshed dependency set.
- `mise run docs` passed.
- `mise run check` passed through `fmt`, `clippy`, Rust tests, `pytest`, `deny`, `typos`, and `vet`.
- `mise run check` still fails locally at `mise run msrv` because `cargo-msrv` panics while creating its initial log file on a read-only filesystem.
