### PR TITLE
fix(ci): refresh cfgcut deps and vet exemptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.0"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f40e41efb5f592d3a0764f818e2f08e5e21c4f368126f74f37c81bd4af7a0c6"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "python3-dll-a",
  "target-lexicon",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -895,27 +895,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
-toml = "1.0"
+toml = "1.1"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -232,6 +232,10 @@ criteria = "safe-to-run"
 version = "1.47.0"
 criteria = "safe-to-run"
 
+[[exemptions.insta]]
+version = "1.47.2"
+criteria = "safe-to-run"
+
 [[exemptions.is_terminal_polyfill]]
 version = "1.70.2"
 criteria = "safe-to-deploy"
@@ -324,20 +328,40 @@ criteria = "safe-to-deploy"
 version = "0.28.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.pyo3]]
+version = "0.28.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.pyo3-build-config]]
 version = "0.28.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-build-config]]
+version = "0.28.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.pyo3-ffi]]
 version = "0.28.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.pyo3-ffi]]
+version = "0.28.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.pyo3-macros]]
 version = "0.28.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.pyo3-macros]]
+version = "0.28.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.pyo3-macros-backend]]
 version = "0.28.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pyo3-macros-backend]]
+version = "0.28.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.python3-dll-a]]
@@ -412,6 +436,10 @@ criteria = "safe-to-run"
 version = "1.1.0"
 criteria = "safe-to-run"
 
+[[exemptions.serde_spanned]]
+version = "1.1.1"
+criteria = "safe-to-run"
+
 [[exemptions.shlex]]
 version = "1.3.0"
 criteria = "safe-to-deploy"
@@ -468,6 +496,10 @@ criteria = "safe-to-run"
 version = "1.1.0+spec-1.1.0"
 criteria = "safe-to-run"
 
+[[exemptions.toml]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-run"
+
 [[exemptions.toml_datetime]]
 version = "1.0.0+spec-1.1.0"
 criteria = "safe-to-run"
@@ -478,6 +510,10 @@ criteria = "safe-to-run"
 
 [[exemptions.toml_datetime]]
 version = "1.1.0+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_datetime]]
+version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.toml_parser]]
@@ -492,6 +528,10 @@ criteria = "safe-to-run"
 version = "1.1.0+spec-1.1.0"
 criteria = "safe-to-run"
 
+[[exemptions.toml_parser]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-run"
+
 [[exemptions.toml_writer]]
 version = "1.0.6+spec-1.1.0"
 criteria = "safe-to-run"
@@ -502,6 +542,10 @@ criteria = "safe-to-run"
 
 [[exemptions.toml_writer]]
 version = "1.1.0+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.toml_writer]]
+version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.unicode-ident]]


### PR DESCRIPTION
Supersedes #53.

This refreshes the cfgcut dependency bump and adds the matching cargo-vet exemptions so the PR is ready for merge after review.

Validation:
- `mise run vet`
- `mise run docs`
- `mise run check` except the repo-local `msrv` step, which hit sandboxed rustup write restrictions here
- `cargo msrv --path crates/cfgcut verify --no-log` with writable temp HOME/RUSTUP_HOME