### PR TITLE
ci: consolidate dependency and workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           toolchain: 1.90
           components: clippy,rustfmt
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/bin
@@ -31,7 +31,7 @@ jobs:
         with:
           version: 2025.10.5
       - name: Install tooling
-        uses: taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
         with:
           tool: >-
             cargo-deny@0.19.0,
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Run checks
         run: mise run check
       - name: Release plan
@@ -63,7 +63,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.90
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/bin
@@ -99,7 +99,7 @@ jobs:
         with:
           toolchain: 1.90
       - name: Cache cargo directories
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Prepare virtualenv
         shell: bash
         run: |

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -130,7 +130,7 @@ jobs:
           "$VENV_PYTHON" -m pytest crates/pycfgcut/tests
 
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.artifact-name }}
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -205,7 +205,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-build-global
           path: |
@@ -250,7 +250,7 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
           advanced-security: false
           config: .github/zizmor.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -599,6 +599,7 @@ version = "0.3.2"
 dependencies = [
  "cfgcut",
  "pyo3",
+ "python3-dll-a",
  "serde_json",
 ]
 

--- a/crates/pycfgcut/Cargo.toml
+++ b/crates/pycfgcut/Cargo.toml
@@ -20,3 +20,6 @@ crate-type = ["cdylib"]
 pyo3 = { workspace = true, features = ["extension-module", "abi3-py39", "macros", "generate-import-lib"] }
 cfgcut = { path = "../cfgcut", version = "0.3.2" }
 serde_json = { workspace = true }
+
+[target.'cfg(windows)'.build-dependencies]
+python3-dll-a = "0.2"

--- a/crates/pycfgcut/build.rs
+++ b/crates/pycfgcut/build.rs
@@ -1,0 +1,22 @@
+#[cfg(windows)]
+fn main() {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH is set");
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV is set");
+
+    if target_env != "msvc" {
+        return;
+    }
+
+    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR is set"))
+        .join("python3-lib");
+
+    // Maturin's abi3 config can point at a Python toolcache directory without python3.lib.
+    python3_dll_a::ImportLibraryGenerator::new(&target_arch, &target_env)
+        .generate(&out_dir)
+        .expect("generate python3 import library");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+}
+
+#[cfg(not(windows))]
+fn main() {}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,4 +19,4 @@ precise-builds = true
 install-path = "~/.local/bin"
 # Whether to install an updater program
 install-updater = false
-github-action-commits = { "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd", "actions/upload-artifact" = "bbbca2ddaa5d8feaa63e36b76fdaad77386f024f", "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" }
+github-action-commits = { "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd", "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -104,6 +104,10 @@ criteria = "safe-to-deploy"
 version = "4.6.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.clap]]
+version = "4.6.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.clap_builder]]
 version = "4.5.59"
 criteria = "safe-to-deploy"
@@ -122,6 +126,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
 version = "4.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_derive]]
+version = "4.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]


### PR DESCRIPTION
## Summary

- update pinned workflow SHAs for cache, setup-uv, install-action, upload-artifact, and zizmor
- update the cargo-dist source config for `actions/upload-artifact`
- regenerate `.github/workflows/release.yml` with cargo-dist instead of hand-editing generated workflow output
- update `clap` and `clap_derive` to 4.6.1 with matching cargo-vet exemptions
- add a Windows MSVC abi3 import-library build step for `pycfgcut` so maturin links against a generated `python3.lib`

## Validation

- `mise run fmt`
- `mise run clippy`
- `mise run vet`
- `mise run dist-plan`
- `mise run test`
- `mise run pytest`

The Windows link fix still needs GitHub Actions to prove the hosted Windows matrix path.
