### PR TITLE
chore(deps): bump python3-dll-a to 0.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "python3-dll-a"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d381ef313ae70b4da5f95f8a4de773c6aa5cd28f73adec4b4a31df70b66780d8"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
 dependencies = [
  "cc",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -376,6 +376,10 @@ criteria = "safe-to-deploy"
 version = "0.2.14"
 criteria = "safe-to-deploy"
 
+[[exemptions.python3-dll-a]]
+version = "0.2.15"
+criteria = "safe-to-deploy"
+
 [[exemptions.quote]]
 version = "1.0.44"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

- bump `python3-dll-a` from 0.2.14 to 0.2.15 in `Cargo.lock`
- add the matching `safe-to-deploy` cargo-vet exemption

This supersedes Dependabot PR #61, which was missing the vet exemption.

## Validation

- `mise run check` reached and passed fmt, clippy, test, pytest, deny, typos, and vet
- `cargo msrv --no-log --path crates/cfgcut verify`

The local aggregate `mise run check` could not complete its final MSRV subtask without extra rustup write access because `cargo-msrv` needed to write under `/home/bc/.rustup`; the direct MSRV verification passed once that access was granted.
