### PR TITLE
chore(deps): update assert_cmd vet exemption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -52,6 +52,10 @@ criteria = "safe-to-run"
 version = "2.2.0"
 criteria = "safe-to-run"
 
+[[exemptions.assert_cmd]]
+version = "2.2.1"
+criteria = "safe-to-run"
+
 [[exemptions.autocfg]]
 version = "1.5.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Updates assert_cmd to 2.2.1 and adds the matching cargo-vet safe-to-run exemption so the Dependabot update passes CI. Verified with mise run check.