### PR TITLE
feat: add scoped sibling projection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,7 @@
 - Add smoke tests for the Python bridge so core scenarios (matches + token extraction) stay green.
 - Enforce `missing_docs = "deny"` once new documentation stabilises so future public API additions stay covered.
 - Add focused rustdoc examples/doc-tests for the `RunRequest` builder, anonymization flow, and token output to lock in the documented surface.
+- Add focused rustdoc examples/doc-tests for scoped predicate/projection matching once the public API usage settles.
 - Introduce layered configuration loading (config file, `CFGCUT_*` environment variables, CLI overrides) so teams can define durable defaults without extra scripting.
 - Prototype an interactive match lab/REPL that lets network engineers iterate on pattern chains (`||`, `|>>|`, comment segments) before running them in batch.
 

--- a/crates/cfgcut/src/lib.rs
+++ b/crates/cfgcut/src/lib.rs
@@ -638,6 +638,12 @@ pub fn run(request: &RunRequest) -> Result<RunOutput, CfgcutError> {
         let mut matched_file = false;
 
         if let Some(scoped) = &scoped_patterns {
+            if inline_matches.is_some() {
+                warnings.push(format!(
+                    "{}: ignoring inline matches because CLI patterns were provided",
+                    path.display()
+                ));
+            }
             let accumulator = apply_scoped_patterns(&parsed, scoped);
             if accumulator.matched {
                 matched_any = true;

--- a/crates/cfgcut/src/lib.rs
+++ b/crates/cfgcut/src/lib.rs
@@ -75,6 +75,11 @@ pub enum CfgcutError {
         /// The raw pattern text supplied by the caller.
         raw: String,
     },
+    /// Scoped projection flags were incomplete.
+    IncompleteScopedProjection {
+        /// The missing part of the scoped projection request.
+        missing: &'static str,
+    },
     /// The requested token destination is not supported.
     UnsupportedTokenDestination,
     /// Serializing structured output failed.
@@ -128,6 +133,9 @@ impl fmt::Display for CfgcutError {
             Self::EmptyPattern { raw } => {
                 write!(f, "match pattern must not be empty (input: '{raw}')")
             }
+            Self::IncompleteScopedProjection { missing } => {
+                write!(f, "scoped projection requires {missing}")
+            }
             Self::UnsupportedTokenDestination => f.write_str("unsupported token destination"),
             Self::Serialization { source } => {
                 write!(f, "failed to serialize token record: {source}")
@@ -149,6 +157,7 @@ impl std::error::Error for CfgcutError {
             | Self::GlobPatternNoMatches { .. }
             | Self::NoPatternsProvided { .. }
             | Self::EmptyPattern { .. }
+            | Self::IncompleteScopedProjection { .. }
             | Self::UnsupportedTokenDestination => None,
         }
     }
@@ -164,6 +173,8 @@ impl From<serde_json::Error> for CfgcutError {
 #[derive(Debug, Clone)]
 pub struct RunRequest {
     matches: Vec<String>,
+    within: Option<String>,
+    requirements: Vec<String>,
     comment_handling: CommentHandling,
     output_mode: OutputMode,
     render_order: RenderOrder,
@@ -301,6 +312,18 @@ impl RunRequest {
         &self.matches
     }
 
+    /// The parent scope used for scoped projection, if configured.
+    #[must_use]
+    pub fn within(&self) -> Option<&str> {
+        self.within.as_deref()
+    }
+
+    /// Descendant predicates required under each scoped projection parent.
+    #[must_use]
+    pub fn requirements(&self) -> &[String] {
+        &self.requirements
+    }
+
     /// The input paths gathered for this run.
     #[must_use]
     pub fn inputs(&self) -> &[PathBuf] {
@@ -336,6 +359,8 @@ impl RunRequest {
 #[derive(Debug, Clone)]
 pub struct RunRequestBuilder {
     matches: Vec<String>,
+    within: Option<String>,
+    requirements: Vec<String>,
     comment_handling: CommentHandling,
     output_mode: OutputMode,
     render_order: RenderOrder,
@@ -348,6 +373,8 @@ impl Default for RunRequestBuilder {
     fn default() -> Self {
         Self {
             matches: Vec::new(),
+            within: None,
+            requirements: Vec::new(),
             comment_handling: CommentHandling::Exclude,
             output_mode: OutputMode::Normal,
             render_order: RenderOrder::Original,
@@ -363,6 +390,20 @@ impl RunRequestBuilder {
     #[must_use]
     pub fn matches(mut self, matches: Vec<String>) -> Self {
         self.matches = matches;
+        self
+    }
+
+    /// Configure a parent scope for predicate/projection matching.
+    #[must_use]
+    pub fn within(mut self, within: Option<String>) -> Self {
+        self.within = within;
+        self
+    }
+
+    /// Replace any existing scoped projection requirements.
+    #[must_use]
+    pub fn requirements(mut self, requirements: Vec<String>) -> Self {
+        self.requirements = requirements;
         self
     }
 
@@ -413,6 +454,8 @@ impl RunRequestBuilder {
     pub fn build(self) -> RunRequest {
         RunRequest {
             matches: self.matches,
+            within: self.within,
+            requirements: self.requirements,
             comment_handling: self.comment_handling,
             output_mode: self.output_mode,
             render_order: self.render_order,
@@ -433,6 +476,50 @@ fn compile_cli_patterns(matches: &[String]) -> Result<Option<Vec<Pattern>>, Cfgc
         compiled.push(Pattern::parse(raw)?);
     }
     Ok(Some(compiled))
+}
+
+struct ScopedPatterns {
+    within: Pattern,
+    requirements: Vec<Pattern>,
+    projections: Vec<Pattern>,
+}
+
+fn compile_scoped_patterns(request: &RunRequest) -> Result<Option<ScopedPatterns>, CfgcutError> {
+    if request.within.is_none() && request.requirements.is_empty() {
+        return Ok(None);
+    }
+
+    let within = request
+        .within
+        .as_deref()
+        .ok_or(CfgcutError::IncompleteScopedProjection {
+            missing: "--within",
+        })?;
+
+    if request.requirements.is_empty() {
+        return Err(CfgcutError::IncompleteScopedProjection {
+            missing: "at least one --require",
+        });
+    }
+    if request.matches.is_empty() {
+        return Err(CfgcutError::IncompleteScopedProjection {
+            missing: "at least one -m/--match projection",
+        });
+    }
+
+    Ok(Some(ScopedPatterns {
+        within: Pattern::parse(within)?,
+        requirements: compile_patterns(&request.requirements)?,
+        projections: compile_patterns(&request.matches)?,
+    }))
+}
+
+fn compile_patterns(patterns: &[String]) -> Result<Vec<Pattern>, CfgcutError> {
+    let mut compiled = Vec::with_capacity(patterns.len());
+    for raw in patterns {
+        compiled.push(Pattern::parse(raw)?);
+    }
+    Ok(compiled)
 }
 
 struct ParsedFile {
@@ -525,6 +612,7 @@ fn compile_inline_patterns(
 pub fn run(request: &RunRequest) -> Result<RunOutput, CfgcutError> {
     let files = collect_files(&request.inputs)?;
     let cli_patterns = compile_cli_patterns(&request.matches)?;
+    let scoped_patterns = compile_scoped_patterns(request)?;
     let include_comments = matches!(request.comment_handling, CommentHandling::Include);
     let anonymize = matches!(request.anonymization, Anonymization::Enabled);
 
@@ -546,23 +634,32 @@ pub fn run(request: &RunRequest) -> Result<RunOutput, CfgcutError> {
             .as_ref()
             .map(|_| TokenAccumulator::new(dialect_kind));
 
-        let (pattern_set, warning) =
-            resolve_patterns(cli_patterns.as_deref(), inline_matches.as_deref(), &path)?;
-        if let Some(message) = warning {
-            warnings.push(message);
-        }
-
         let mut indices = BTreeSet::new();
         let mut matched_file = false;
 
-        for pattern in pattern_set.iter() {
-            let mut accumulator = MatchAccumulator::new(&parsed);
-            pattern.apply(&parsed, &mut accumulator);
+        if let Some(scoped) = &scoped_patterns {
+            let accumulator = apply_scoped_patterns(&parsed, scoped);
             if accumulator.matched {
                 matched_any = true;
                 matched_file = true;
             }
             indices.extend(accumulator.indices);
+        } else {
+            let (pattern_set, warning) =
+                resolve_patterns(cli_patterns.as_deref(), inline_matches.as_deref(), &path)?;
+            if let Some(message) = warning {
+                warnings.push(message);
+            }
+
+            for pattern in pattern_set.iter() {
+                let mut accumulator = MatchAccumulator::new(&parsed);
+                pattern.apply(&parsed, &mut accumulator);
+                if accumulator.matched {
+                    matched_any = true;
+                    matched_file = true;
+                }
+                indices.extend(accumulator.indices);
+            }
         }
 
         if matched_file {
@@ -760,22 +857,31 @@ impl Pattern {
             return;
         }
 
-        let roots: Vec<usize> = config
-            .lines
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, line)| {
-                if line.parent.is_none() {
-                    Some(idx)
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let roots = root_indices(config);
+        self.apply_from_roots(config, &roots, accumulator);
+    }
 
+    fn apply_from_roots(
+        &self,
+        config: &ParsedConfig,
+        roots: &[usize],
+        accumulator: &mut MatchAccumulator,
+    ) {
         for root in roots {
-            self.walk(config, root, 0, accumulator);
+            self.walk(config, *root, 0, accumulator);
         }
+    }
+
+    fn terminal_matches_from_roots(
+        &self,
+        config: &ParsedConfig,
+        roots: &[usize],
+    ) -> BTreeSet<usize> {
+        let mut matches = BTreeSet::new();
+        for &root in roots {
+            self.collect_terminals(config, root, 0, &mut matches);
+        }
+        matches
     }
 
     fn walk(
@@ -819,6 +925,94 @@ impl Pattern {
             }
         }
     }
+
+    fn collect_terminals(
+        &self,
+        config: &ParsedConfig,
+        node_idx: usize,
+        segment_idx: usize,
+        matches: &mut BTreeSet<usize>,
+    ) {
+        if segment_idx >= self.segments.len() {
+            return;
+        }
+
+        match &self.segments[segment_idx] {
+            PatternSegment::DescendAll => {
+                matches.insert(node_idx);
+            }
+            PatternSegment::Match { regex, target } => {
+                let line = &config.lines[node_idx];
+                if !target.matches(line.kind) {
+                    return;
+                }
+                if let Some(candidate) = line.match_text.as_deref() {
+                    if !regex.is_match(candidate) {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+
+                if segment_idx + 1 == self.segments.len() {
+                    matches.insert(node_idx);
+                } else if matches!(self.segments[segment_idx + 1], PatternSegment::DescendAll) {
+                    self.collect_terminals(config, node_idx, segment_idx + 1, matches);
+                } else {
+                    for &child in &config.children[node_idx] {
+                        self.collect_terminals(config, child, segment_idx + 1, matches);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn root_indices(config: &ParsedConfig) -> Vec<usize> {
+    config
+        .lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| {
+            if line.parent.is_none() {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn apply_scoped_patterns<'a>(
+    config: &'a ParsedConfig,
+    scoped: &ScopedPatterns,
+) -> MatchAccumulator<'a> {
+    let roots = root_indices(config);
+    let scope_nodes = scoped.within.terminal_matches_from_roots(config, &roots);
+    let mut output = MatchAccumulator::new(config);
+
+    for scope in scope_nodes {
+        let child_roots = &config.children[scope];
+        let has_requirements = scoped.requirements.iter().all(|requirement| {
+            !requirement
+                .terminal_matches_from_roots(config, child_roots)
+                .is_empty()
+        });
+        if !has_requirements {
+            continue;
+        }
+
+        for projection in &scoped.projections {
+            let mut accumulator = MatchAccumulator::new(config);
+            projection.apply_from_roots(config, child_roots, &mut accumulator);
+            if accumulator.matched {
+                output.matched = true;
+            }
+            output.indices.extend(accumulator.indices);
+        }
+    }
+
+    output
 }
 
 fn create_segment(

--- a/crates/cfgcut/src/main.rs
+++ b/crates/cfgcut/src/main.rs
@@ -14,7 +14,7 @@ use cfgcut::{
     name = "cfgcut",
     about = "Extract configuration sections from text files.",
     long_about = None,
-    after_help = "Match segments are separated with '||' and implicitly anchored. Append '|>>|' to include descendant nodes, use '|#|' for comments with -c/--with-comments, and enable -a/--anonymize to scramble sensitive tokens while keeping structure intact.",
+    after_help = "Match segments are separated with '||' and implicitly anchored. Append '|>>|' to include descendant nodes, use '|#|' for comments with -c/--with-comments, and combine --within/--require with -m to project siblings from qualifying parent scopes.",
     version
 )]
 #[expect(
@@ -30,6 +30,14 @@ struct Cli {
         value_name = "MATCH"
     )]
     matches: Vec<String>,
+
+    /// Parent scope used for descendant predicates and projected sibling output
+    #[arg(long = "within", value_name = "MATCH")]
+    within: Option<String>,
+
+    /// Descendant match required under each --within scope
+    #[arg(long = "require", action = ArgAction::Append, value_name = "MATCH")]
+    requirements: Vec<String>,
 
     /// Include comments in the output stream
     #[arg(short = 'c', long = "with-comments")]
@@ -65,6 +73,8 @@ fn main() {
 
     let Cli {
         matches,
+        within,
+        requirements,
         with_comments,
         sort_by_path,
         quiet,
@@ -76,6 +86,8 @@ fn main() {
 
     let request = RunRequest::builder()
         .matches(matches)
+        .within(within)
+        .requirements(requirements)
         .comment_handling(if with_comments {
             CommentHandling::Include
         } else {

--- a/crates/cfgcut/tests/cli_help.rs
+++ b/crates/cfgcut/tests/cli_help.rs
@@ -35,7 +35,9 @@ fn help_mentions_matching_defaults() {
         .assert()
         .success()
         .stdout(contains("implicitly anchored"))
-        .stdout(contains("-a/--anonymize"))
+        .stdout(contains("--within"))
+        .stdout(contains("--require"))
+        .stdout(contains("-a, --anonymize"))
         .stdout(contains("--tokens"));
 }
 

--- a/crates/cfgcut/tests/inline_matches.rs
+++ b/crates/cfgcut/tests/inline_matches.rs
@@ -54,3 +54,24 @@ fn inline_matches_emit_warning_when_cli_provided() {
         .stdout(predicate::str::diff(expected))
         .stderr(predicate::str::contains("ignoring inline matches"));
 }
+
+#[test]
+fn inline_matches_emit_warning_when_scoped_cli_provided() {
+    let path = fixture("cisco_ios/inline.conf");
+    let body = "interface GigabitEthernet0/1\n description uplink\n";
+    let expected = expected_with_header("!", &path, body);
+    cfgcut_cmd()
+        .args([
+            "--within",
+            "interface .*",
+            "--require",
+            "description uplink",
+            "-m",
+            "description uplink",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::diff(expected))
+        .stderr(predicate::str::contains("ignoring inline matches"));
+}

--- a/crates/cfgcut/tests/match_extended.rs
+++ b/crates/cfgcut/tests/match_extended.rs
@@ -142,6 +142,79 @@ fn multiple_match_patterns_union_results() {
 }
 
 #[test]
+fn scoped_projection_filters_ios_sibling_lines_by_required_descendant() {
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("access.cfg");
+    fs::write(
+        &path,
+        "\
+interface GigabitEthernet1/0/1
+ switchport access vlan 120
+ switchport port-security mac-address sticky
+ switchport port-security mac-address sticky 0011.2233.4455
+!
+interface GigabitEthernet1/0/2
+ switchport access vlan 130
+!
+",
+    )
+    .unwrap();
+    let path_str = path.to_string_lossy().into_owned();
+
+    let mut cmd = cfgcut_cmd();
+    cmd.args([
+        "--within",
+        "interface .*",
+        "--require",
+        "switchport port-security mac-address sticky(?: .*)?",
+        "-m",
+        "switchport access vlan .*",
+        "-m",
+        "switchport port-security mac-address sticky(?: .*)?",
+        path_str.as_str(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(header("!", &path)))
+    .stdout(predicate::str::contains("interface GigabitEthernet1/0/1"))
+    .stdout(predicate::str::contains("switchport access vlan 120"))
+    .stdout(predicate::str::contains(
+        "switchport port-security mac-address sticky 0011.2233.4455",
+    ))
+    .stdout(predicate::str::contains("interface GigabitEthernet1/0/2").not())
+    .stdout(predicate::str::contains("switchport access vlan 130").not());
+}
+
+#[test]
+fn scoped_projection_filters_nested_junos_sibling_lines() {
+    let path = fixture_path("juniper_junos/full_lab.conf");
+    let header_line = header("##", &path);
+    let path_str = path.to_string_lossy().into_owned();
+
+    let mut cmd = cfgcut_cmd();
+    cmd.args([
+        "--within",
+        "interfaces||ge-.*",
+        "--require",
+        "unit 0||family ethernet-switching",
+        "-m",
+        "description .*",
+        "-m",
+        "unit 0||family ethernet-switching||vlan||members .*",
+        path_str.as_str(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(&header_line))
+    .stdout(predicate::str::contains("interfaces {"))
+    .stdout(predicate::str::contains("ge-0/0/1 {"))
+    .stdout(predicate::str::contains("description \"user access\";"))
+    .stdout(predicate::str::contains("members [ users voice ];"))
+    .stdout(predicate::str::contains("ge-0/0/0 {").not())
+    .stdout(predicate::str::contains("description \"to core\";").not());
+}
+
+#[test]
 fn directory_input_collects_files() {
     let tmp = tempdir().unwrap();
     let dir = tmp.path();

--- a/crates/pycfgcut/src/lib.rs
+++ b/crates/pycfgcut/src/lib.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
 
 #[pyfunction]
-#[pyo3(signature = (matches, inputs, with_comments = false, sort_by_path = false, quiet = false, anonymize = false, tokens = false, tokens_out = None))]
+#[pyo3(signature = (matches, inputs, with_comments = false, sort_by_path = false, quiet = false, anonymize = false, tokens = false, tokens_out = None, within = None, requirements = None))]
 #[expect(
     clippy::too_many_arguments,
     reason = "Python binding mirrors the CLI surface without breaking parameters"
@@ -25,6 +25,8 @@ fn run_cfg(
     anonymize: bool,
     tokens: bool,
     tokens_out: Option<String>,
+    within: Option<String>,
+    requirements: Option<Vec<String>>,
 ) -> PyResult<Py<PyAny>> {
     if matches.is_empty() {
         return Err(PyRuntimeError::new_err(
@@ -45,6 +47,8 @@ fn run_cfg(
 
     let request = RunRequest::builder()
         .matches(matches)
+        .within(within)
+        .requirements(requirements.unwrap_or_default())
         .comment_handling(if with_comments {
             CommentHandling::Include
         } else {

--- a/crates/pycfgcut/tests/test_smoke.py
+++ b/crates/pycfgcut/tests/test_smoke.py
@@ -32,6 +32,40 @@ def test_with_comments_includes_comment_lines(tmp_path: Path):
     assert "## comment marker" in result["stdout"]
 
 
+def test_scoped_projection_filters_siblings(tmp_path: Path):
+    config = tmp_path / "access.cfg"
+    config.write_text(
+        "\n".join(
+            [
+                "interface GigabitEthernet1/0/1",
+                " switchport access vlan 120",
+                " switchport port-security mac-address sticky",
+                "!",
+                "interface GigabitEthernet1/0/2",
+                " switchport access vlan 130",
+                "!",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_cfg(
+        [
+            "switchport access vlan .*",
+            "switchport port-security mac-address sticky",
+        ],
+        [str(config)],
+        within="interface .*",
+        requirements=["switchport port-security mac-address sticky"],
+    )
+
+    assert result["matched"] is True
+    assert "interface GigabitEthernet1/0/1" in result["stdout"]
+    assert "switchport access vlan 120" in result["stdout"]
+    assert "interface GigabitEthernet1/0/2" not in result["stdout"]
+    assert "switchport access vlan 130" not in result["stdout"]
+
+
 def test_tokens_written_to_file(tmp_path: Path):
     fixture = _fixture_path("arista_eos/sample.conf")
     output = tmp_path / "tokens.jsonl"

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -7,6 +7,8 @@
 | Option | Description |
 | --- | --- |
 | `-m, --match <MATCH>` | Hierarchical regex segments (anchored). Repeat the flag for multiple patterns; takes precedence over inline blocks. |
+| `--within <MATCH>` | Parent scope used with `--require` and `-m` to project only descendants from qualifying parents. |
+| `--require <MATCH>` | Descendant predicate required under each `--within` scope. Repeat the flag to require multiple predicates. |
 | `-c, --with-comments` | Include comment lines recognised by the active dialect. |
 | `--sort-by-path` | Order output by hierarchical path instead of source order (useful for diffing). |
 | `-q, --quiet` | Suppress stdout; rely on exit status to detect matches. |
@@ -27,6 +29,7 @@ Configurations are parsed into a hierarchy. Use `||` to move down levels and pla
 
 - Every segment is wrapped with `^...$` automatically. `ge-.*` targets individual interfaces rather than matching a partial line.
 - Matches print their ancestor context so output remains valid configuration. Without `|>>|`, only the matched line plus its parents are shown.
+- Repeating `-m/--match` unions independent outputs. It does not correlate sibling matches under a shared parent.
 - Comment markers are normalised per dialect (for example `!` on IOS, `#` on Junos). Opt into printing them with `-c/--with-comments`.
 
 Example: fetch every trunk interface from a Cisco IOS device while keeping parent context.
@@ -45,6 +48,20 @@ To normalize output for diffing:
 
 ```bash
 cfgcut --sort-by-path -m 'interface .*|>>|' tests/fixtures/cisco_ios/sample.conf
+```
+
+To select a parent by one descendant and print selected sibling descendants from
+the same parent, combine `--within`, `--require`, and one or more projection
+matches. This example prints the access VLAN and sticky MAC commands only under
+interfaces that contain sticky MAC configuration:
+
+```bash
+cfgcut \
+  --within 'interface .*' \
+  --require 'switchport port-security mac-address sticky(?: .*)?' \
+  -m 'switchport access vlan .*' \
+  -m 'switchport port-security mac-address sticky(?: .*)?' \
+  device.conf
 ```
 
 ### Inline match blocks


### PR DESCRIPTION
Summary
- Add `--within` and repeatable `--require` flags for parent-scoped predicate/projection matching.
- Keep repeated `-m` union behavior unchanged while allowing sibling projection only under qualifying parent scopes.
- Extend the same scoped matcher surface to `pycfgcut.run_cfg` and preserve inline-match warnings for scoped CLI invocations.
- Document the new CLI flow and cover IOS plus nested Junos behavior.

Why
- Closes #70.
- Users can now select a parent by a descendant predicate, then emit selected sibling descendants without leaking lines from non-qualifying parents.

Validation
- `cargo fmt --all --check`
- `RUSTFLAGS='-C linker=clang -C link-arg=-fuse-ld=lld' cargo test --workspace --exclude pycfgcut`
- `RUSTFLAGS='-C linker=clang -C link-arg=-fuse-ld=lld' cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTFLAGS='-C linker=clang -C link-arg=-fuse-ld=lld' mise run pytest`
