### PR TITLE
chore(deps): bump serde_json to 1.0.150

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -448,6 +448,10 @@ criteria = "safe-to-deploy"
 version = "1.0.149"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde_json]]
+version = "1.0.150"
+criteria = "safe-to-deploy"
+
 [[exemptions.serde_spanned]]
 version = "1.0.4"
 criteria = "safe-to-run"


### PR DESCRIPTION
Summary
- bump serde_json from 1.0.149 to 1.0.150
- add the matching cargo-vet safe-to-deploy exemption

Refs #74.

Validation
- RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=lld" mise run check (fmt, clippy, tests, pytest, deny, typos, vet passed; local msrv hit the known rustup linker/log path issue)
- XDG_DATA_HOME=/tmp/cfgcut-xdg-data XDG_STATE_HOME=/tmp/cfgcut-xdg-state XDG_CACHE_HOME=/home/bc/.cache CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=lld" cargo msrv --path crates/cfgcut verify
- RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=lld" mise run docs
- mise run dist-plan