### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0 - 2026-06-01
+
+- add scoped sibling projection with `--within` and repeatable `--require`, letting matches emit selected sibling descendants only from parent scopes that satisfy required descendant predicates
+- expose the scoped matching options through `pycfgcut.run_cfg` so Python callers can use the same `--within` and `--require` behavior as the CLI
+- document scoped projection in the usage guide and cover IOS plus nested Junos cases in the test suite
+- update supply-chain and workflow dependencies, including `assert_cmd` 2.2.2, `serde_json` 1.0.150, `taiki-e/install-action` 2.78.0, and `zizmor-action` 0.5.5
+
 ## 0.3.2 - 2025-10-17
 
 - fix Cisco banner parsing across IOS, IOS-XE, IOS-XR, NX-OS, and other indent dialects by tracking custom delimiters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfgcut"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "pycfgcut"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cfgcut",
  "pyo3",

--- a/crates/cfgcut/Cargo.toml
+++ b/crates/cfgcut/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfgcut"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT OR Apache-2.0"

--- a/crates/cfgcut/tests/cli_help.rs
+++ b/crates/cfgcut/tests/cli_help.rs
@@ -47,7 +47,7 @@ fn version_reports_semver() {
     cmd.arg("--version")
         .assert()
         .success()
-        .stdout(contains("cfgcut").and(contains("0.3.2")));
+        .stdout(contains("cfgcut").and(contains("0.4.0")));
 }
 
 #[test]

--- a/crates/pycfgcut/Cargo.toml
+++ b/crates/pycfgcut/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pycfgcut"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 publish = false
 description = "Python bindings for cfgcut, the deterministic configuration slicer"
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { workspace = true, features = ["extension-module", "abi3-py39", "macros", "generate-import-lib"] }
-cfgcut = { path = "../cfgcut", version = "0.3.2" }
+cfgcut = { path = "../cfgcut", version = "0.4.0" }
 serde_json = { workspace = true }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,8 +12,8 @@ This repository publishes both the Rust CLI (`cfgcut`) and the Python bindings (
 
 1. Create an annotated tag that matches the desired semantic version, for example:
    ```bash
-   git tag -a v0.3.2 -m "cfgcut v0.3.2"
-   git push origin v0.3.2
+   git tag -a v0.4.0 -m "cfgcut v0.4.0"
+   git push origin v0.4.0
    ```
 2. The `Release` workflow builds:
    - cfgcut binaries for Linux (GNU + musl), macOS (x86_64 + arm64), and Windows.


### PR DESCRIPTION
Summary
- bump cfgcut and pycfgcut crate versions to 0.4.0
- update the changelog with scoped sibling projection and recent dependency/workflow updates
- update release docs and the version assertion for 0.4.0

Validation
- cargo metadata --locked --no-deps --format-version 1
- RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=lld" mise run check (fmt, clippy, tests, pytest, deny, typos, vet passed; local msrv hit the known log-path issue)
- XDG_DATA_HOME=/tmp/cfgcut-xdg-data XDG_STATE_HOME=/tmp/cfgcut-xdg-state XDG_CACHE_HOME=/home/bc/.cache CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=lld" cargo msrv --path crates/cfgcut verify
- RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=lld" mise run docs
- mise run dist-plan