### PR TITLE
ci: update cargo-dist checkout pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
           submodules: recursive
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
           submodules: recursive
@@ -175,7 +175,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
           submodules: recursive
@@ -225,7 +225,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
           submodules: recursive
@@ -290,7 +290,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
           submodules: recursive

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,4 +19,4 @@ precise-builds = true
 install-path = "~/.local/bin"
 # Whether to install an updater program
 install-updater = false
-github-action-commits = { "actions/checkout" = "df4cb1c069e1874edd31b4311f1884172cec0e10", "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" }
+github-action-commits = { "actions/checkout" = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" }


### PR DESCRIPTION
Updates cargo-dist source-of-truth metadata for actions/checkout so the generated release workflow stays aligned with Dependabot PR #84.

Validation:
- UV_TOOL_DIR=/tmp/uv-tools UV_CACHE_DIR=/tmp/uv-cache uvx zizmor --config .github/zizmor.yml --min-severity medium --persona regular .
- PATH=/tmp/cargo-dist-0.30.3/bin:$PATH dist plan